### PR TITLE
feat: add shared rate limiter with Polymarket API presets

### DIFF
--- a/examples/data_api_demo.ml
+++ b/examples/data_api_demo.ml
@@ -32,12 +32,16 @@ let run_demo env =
   Logger.setup ();
   Eio.Switch.run @@ fun sw ->
   let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
 
   Logger.info "START"
     [ ("demo", "Data API"); ("base_url", Data.default_base_url) ];
 
+  (* Create shared rate limiter with Polymarket presets *)
+  let rate_limiter = Rate_limiter.create_polymarket ~clock () in
+
   (* Create the client *)
-  let client = Data.create ~sw ~net () in
+  let client = Data.create ~sw ~net ~rate_limiter () in
 
   (* Health Check *)
   Logger.header "Health Check";

--- a/examples/gamma_api_demo.ml
+++ b/examples/gamma_api_demo.ml
@@ -56,11 +56,14 @@ let run_demo env =
   Logger.setup ();
   Eio.Switch.run @@ fun sw ->
   let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
 
   Logger.info "START"
     [ ("demo", "Gamma API"); ("base_url", Gamma.default_base_url) ];
 
-  let client = Gamma.create ~sw ~net () in
+  (* Create shared rate limiter with Polymarket presets *)
+  let rate_limiter = Rate_limiter.create_polymarket ~clock () in
+  let client = Gamma.create ~sw ~net ~rate_limiter () in
 
   (* ===== Health Check ===== *)
   Logger.header "Health Check";

--- a/lib/clob_api/client.ml
+++ b/lib/clob_api/client.ml
@@ -14,8 +14,9 @@ type t = {
 
 let default_base_url = "https://clob.polymarket.com"
 
-let create ?(base_url = default_base_url) ?credentials ?address ~sw ~net () =
-  let http = H.create ~base_url ~sw ~net () in
+let create ?(base_url = default_base_url) ?credentials ?address ~sw ~net
+    ~rate_limiter () =
+  let http = H.create ~base_url ~sw ~net ~rate_limiter () in
   { http; credentials; address }
 
 let with_credentials t ~credentials ~address =

--- a/lib/clob_api/client.mli
+++ b/lib/clob_api/client.mli
@@ -14,6 +14,7 @@ val create :
   ?address:string ->
   sw:Eio.Switch.t ->
   net:_ Eio.Net.t ->
+  rate_limiter:Polymarket_rate_limiter.Rate_limiter.t ->
   unit ->
   t
 (** Create a new CLOB API client.
@@ -22,7 +23,8 @@ val create :
     @param address
       Optional Ethereum address (required if credentials are provided)
     @param sw The Eio switch for resource management
-    @param net The Eio network capability *)
+    @param net The Eio network capability
+    @param rate_limiter Shared rate limiter for enforcing API limits *)
 
 val with_credentials :
   t -> credentials:Auth_types.credentials -> address:string -> t

--- a/lib/data_api/client.ml
+++ b/lib/data_api/client.ml
@@ -14,8 +14,8 @@ module P = Polymarket_common.Primitives
 
 let default_base_url = "https://data-api.polymarket.com"
 
-let create ?(base_url = default_base_url) ~sw ~net () =
-  H.create ~base_url ~sw ~net ()
+let create ?(base_url = default_base_url) ~sw ~net ~rate_limiter () =
+  H.create ~base_url ~sw ~net ~rate_limiter ()
 
 (** {1 Health Endpoint} *)
 

--- a/lib/data_api/client.mli
+++ b/lib/data_api/client.mli
@@ -26,11 +26,18 @@ type t
 val default_base_url : string
 (** Default base URL for the Polymarket Data API *)
 
-val create : ?base_url:string -> sw:Eio.Switch.t -> net:_ Eio.Net.t -> unit -> t
+val create :
+  ?base_url:string ->
+  sw:Eio.Switch.t ->
+  net:_ Eio.Net.t ->
+  rate_limiter:Polymarket_rate_limiter.Rate_limiter.t ->
+  unit ->
+  t
 (** Create a new client instance.
     @param base_url The API base URL (default: {!default_base_url})
     @param sw The Eio switch for resource management
-    @param net The Eio network capability *)
+    @param net The Eio network capability
+    @param rate_limiter Shared rate limiter for enforcing API limits *)
 
 (** {1 Health Endpoint} *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -4,6 +4,7 @@
  (libraries
   polymarket_common
   polymarket_http
+  polymarket_rate_limiter
   polymarket_clob
   polymarket_data
   polymarket_gamma))

--- a/lib/gamma_api/client.ml
+++ b/lib/gamma_api/client.ml
@@ -14,8 +14,8 @@ type t = Polymarket_http.Client.t
 
 let default_base_url = "https://gamma-api.polymarket.com"
 
-let create ?(base_url = default_base_url) ~sw ~net () =
-  H.create ~base_url ~sw ~net ()
+let create ?(base_url = default_base_url) ~sw ~net ~rate_limiter () =
+  H.create ~base_url ~sw ~net ~rate_limiter ()
 
 (** {1 Health Endpoint} *)
 

--- a/lib/gamma_api/client.mli
+++ b/lib/gamma_api/client.mli
@@ -27,11 +27,18 @@ type t
 val default_base_url : string
 (** Default base URL for the Polymarket Gamma API *)
 
-val create : ?base_url:string -> sw:Eio.Switch.t -> net:_ Eio.Net.t -> unit -> t
+val create :
+  ?base_url:string ->
+  sw:Eio.Switch.t ->
+  net:_ Eio.Net.t ->
+  rate_limiter:Polymarket_rate_limiter.Rate_limiter.t ->
+  unit ->
+  t
 (** Create a new client instance.
     @param base_url The API base URL (default: {!default_base_url})
     @param sw The Eio switch for resource management
-    @param net The Eio network capability *)
+    @param net The Eio network capability
+    @param rate_limiter Shared rate limiter for enforcing API limits *)
 
 (** {1 Health Endpoint} *)
 

--- a/lib/http_client/client.mli
+++ b/lib/http_client/client.mli
@@ -8,11 +8,18 @@
 type t
 (** The client type holding connection configuration *)
 
-val create : base_url:string -> sw:Eio.Switch.t -> net:_ Eio.Net.t -> unit -> t
+val create :
+  base_url:string ->
+  sw:Eio.Switch.t ->
+  net:_ Eio.Net.t ->
+  rate_limiter:Polymarket_rate_limiter.Rate_limiter.t ->
+  unit ->
+  t
 (** Create a new client instance.
     @param base_url The API base URL
     @param sw The Eio switch for resource management
-    @param net The Eio network capability *)
+    @param net The Eio network capability
+    @param rate_limiter Shared rate limiter for enforcing API limits *)
 
 val base_url : t -> string
 (** Get the base URL of the client *)

--- a/lib/http_client/dune
+++ b/lib/http_client/dune
@@ -3,6 +3,7 @@
  (public_name polymarket.http)
  (libraries
   polymarket_common
+  polymarket_rate_limiter
   yojson
   ppx_yojson_conv_lib
   cohttp-eio

--- a/lib/polymarket.ml
+++ b/lib/polymarket.ml
@@ -41,6 +41,9 @@ end
 module Http = Polymarket_http.Client
 (** HTTP client utilities for making API requests. *)
 
+module Rate_limiter = Polymarket_rate_limiter.Rate_limiter
+(** Route-based rate limiting middleware. *)
+
 (** {1 Primitive Types}
 
     Validated types for addresses, hashes, and numeric constraints. These are

--- a/lib/polymarket.mli
+++ b/lib/polymarket.mli
@@ -5,6 +5,7 @@
     - {!Data}: Positions, trades, activity, and leaderboards
       (data-api.polymarket.com)
     - {!Clob}: Order books, pricing, and trading (clob.polymarket.com)
+    - {!Rate_limiter}: Route-based rate limiting middleware
 
     {2 Example Usage}
 
@@ -15,6 +16,18 @@
       match Polymarket.Gamma.get_events client () with
       | Ok events -> List.iter (fun e -> print_endline e.title) events
       | Error err -> print_endline ("Error: " ^ err.error)
+    ]}
+
+    {2 Rate Limiting}
+
+    Pass a clock to enable automatic rate limiting with Polymarket API presets:
+
+    {[
+      let client =
+        Polymarket.Gamma.create ~sw ~net:(Eio.Stdenv.net env)
+          ~clock:(Eio.Stdenv.clock env) ()
+      in
+      (* Requests are now automatically rate limited *)
     ]}
 
     {2 Validated Primitive Types}
@@ -32,6 +45,7 @@
     For finer-grained control, you can depend on sub-libraries directly:
     - [polymarket.common]: Shared primitives and logging
     - [polymarket.http]: HTTP client utilities
+    - [polymarket.rate_limiter]: Rate limiting middleware
     - [polymarket.gamma]: Gamma API client
     - [polymarket.data]: Data API client
     - [polymarket.clob]: CLOB API client *)
@@ -72,6 +86,9 @@ end
 
 module Http = Polymarket_http.Client
 (** HTTP client utilities for making API requests. *)
+
+module Rate_limiter = Polymarket_rate_limiter.Rate_limiter
+(** Route-based rate limiting middleware for HTTP clients. *)
 
 (** {1 Primitive Types}
 

--- a/lib/rate_limiter/builder.ml
+++ b/lib/rate_limiter/builder.ml
@@ -1,0 +1,66 @@
+(** Fluent builder for rate limit configurations. *)
+
+type t = {
+  host : string option;
+  method_ : string option;
+  path_prefix : string option;
+  limits : Types.limit_config list;
+  behavior : Types.behavior option;
+}
+
+let route () =
+  {
+    host = None;
+    method_ = None;
+    path_prefix = None;
+    limits = [];
+    behavior = None;
+  }
+
+let host h t = { t with host = Some h }
+let method_ m t = { t with method_ = Some m }
+let path p t = { t with path_prefix = Some p }
+
+let limit ~requests ~window_seconds t =
+  let lim = Types.limit ~requests ~window_seconds in
+  { t with limits = t.limits @ [ lim ] }
+
+let on_limit b t = { t with behavior = Some b }
+
+let build t : Types.route_config =
+  if t.limits = [] then
+    invalid_arg "Builder.build: at least one limit must be configured";
+  let pattern : Types.route_pattern =
+    { host = t.host; method_ = t.method_; path_prefix = t.path_prefix }
+  in
+  let behavior = Option.value ~default:Types.Delay t.behavior in
+  { pattern; limits = t.limits; behavior }
+
+let simple ?host:h ?method_:m ?path:p ~requests ~window_seconds ?behavior () =
+  let b = route () in
+  let b = match h with Some hv -> host hv b | None -> b in
+  let b = match m with Some mv -> method_ mv b | None -> b in
+  let b = match p with Some pv -> path pv b | None -> b in
+  let b = limit ~requests ~window_seconds b in
+  let b = match behavior with Some beh -> on_limit beh b | None -> b in
+  build b
+
+let global ~requests ~window_seconds ~behavior =
+  simple ~requests ~window_seconds ~behavior ()
+
+let per_host ~host ~requests ~window_seconds ~behavior =
+  simple ~host ~requests ~window_seconds ~behavior ()
+
+let per_endpoint ~host ~method_ ~path ~requests ~window_seconds ~behavior =
+  simple ~host ~method_ ~path ~requests ~window_seconds ~behavior ()
+
+(* Host-scoped builder *)
+type host_builder = { hb_host : string; routes : t list }
+
+let for_host h = { hb_host = h; routes = [] }
+
+let add_route r hb =
+  let r_with_host = { r with host = Some hb.hb_host } in
+  { hb with routes = hb.routes @ [ r_with_host ] }
+
+let build_host hb = List.map build hb.routes

--- a/lib/rate_limiter/builder.mli
+++ b/lib/rate_limiter/builder.mli
@@ -1,0 +1,109 @@
+(** Fluent builder for rate limit configurations.
+
+    This module provides a chainable API for building route configurations,
+    similar to the Rust route-ratelimit crate.
+
+    Example:
+    {[
+      route () |> host "api.example.com" |> method_ "POST" |> path "/orders"
+      |> limit ~requests:100 ~window_seconds:10.0
+      |> limit ~requests:1000 ~window_seconds:600.0
+      |> on_limit Delay |> build
+    ]} *)
+
+type t
+(** Builder state *)
+
+val route : unit -> t
+(** Start building a route configuration *)
+
+(** {1 Pattern Matching} *)
+
+val host : string -> t -> t
+(** Match requests to a specific host *)
+
+val method_ : string -> t -> t
+(** Match requests with a specific HTTP method (case-insensitive) *)
+
+val path : string -> t -> t
+(** Match requests with a path prefix (uses segment boundaries) *)
+
+(** {1 Rate Limits}
+
+    Multiple limits can be applied to the same route. All limits must pass for a
+    request to proceed. This enables burst + sustained limit patterns. *)
+
+val limit : requests:int -> window_seconds:float -> t -> t
+(** Add a rate limit. Can be called multiple times to add multiple limits.
+    Example: [limit ~requests:100 ~window_seconds:10.0] for 100 req/10s *)
+
+(** {1 Behavior} *)
+
+val on_limit : Types.behavior -> t -> t
+(** Set what happens when the rate limit is exceeded.
+    - [Delay]: Sleep until the request can proceed (default)
+    - [Error]: Return an error immediately *)
+
+(** {1 Building} *)
+
+val build : t -> Types.route_config
+(** Build the final route configuration. Uses [Delay] behavior if not specified.
+    At least one limit must be configured. *)
+
+(** {1 Convenience Constructors} *)
+
+val simple :
+  ?host:string ->
+  ?method_:string ->
+  ?path:string ->
+  requests:int ->
+  window_seconds:float ->
+  ?behavior:Types.behavior ->
+  unit ->
+  Types.route_config
+(** Create a simple route configuration with a single limit. Example:
+    {[
+      simple ~host:"api.example.com" ~requests:100 ~window_seconds:10.0 ()
+    ]} *)
+
+val global :
+  requests:int ->
+  window_seconds:float ->
+  behavior:Types.behavior ->
+  Types.route_config
+(** Create a global rate limit that matches all routes *)
+
+val per_host :
+  host:string ->
+  requests:int ->
+  window_seconds:float ->
+  behavior:Types.behavior ->
+  Types.route_config
+(** Create a rate limit for all routes to a specific host *)
+
+val per_endpoint :
+  host:string ->
+  method_:string ->
+  path:string ->
+  requests:int ->
+  window_seconds:float ->
+  behavior:Types.behavior ->
+  Types.route_config
+(** Create a rate limit for a specific endpoint *)
+
+(** {1 Host-Scoped Builder}
+
+    For organizing rate limits by host, similar to the Rust library's
+    [.host("...", |h| ...)] pattern. *)
+
+type host_builder
+(** Builder for routes scoped to a host *)
+
+val for_host : string -> host_builder
+(** Start building routes for a specific host *)
+
+val add_route : t -> host_builder -> host_builder
+(** Add a route to the host builder. The route inherits the host. *)
+
+val build_host : host_builder -> Types.route_config list
+(** Build all routes for this host *)

--- a/lib/rate_limiter/dune
+++ b/lib/rate_limiter/dune
@@ -1,0 +1,6 @@
+(library
+ (name polymarket_rate_limiter)
+ (public_name polymarket.rate_limiter)
+ (libraries eio uri)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq)))

--- a/lib/rate_limiter/gcra.ml
+++ b/lib/rate_limiter/gcra.ml
@@ -1,0 +1,41 @@
+(** Generic Cell Rate Algorithm (GCRA) for rate limiting. *)
+
+type t = {
+  mutable tat : float;  (** Theoretical Arrival Time *)
+  emission_interval : float;  (** Time between requests at sustained rate *)
+  burst_allowance : float;  (** Maximum burst allowance in seconds *)
+}
+
+let create (config : Types.limit_config) =
+  let emission_interval =
+    config.window_seconds /. float_of_int config.requests
+  in
+  let burst_allowance = config.window_seconds in
+  { tat = 0.0; emission_interval; burst_allowance }
+
+let check t ~now =
+  let allow_at = t.tat -. t.burst_allowance in
+  if now >= allow_at then Ok ()
+  else
+    let retry_after = allow_at -. now in
+    Error retry_after
+
+let update t ~now =
+  let new_tat = Float.max now t.tat +. t.emission_interval in
+  t.tat <- new_tat
+
+let check_and_update t ~now =
+  match check t ~now with
+  | Error _ as e -> e
+  | Ok () ->
+      update t ~now;
+      Ok ()
+
+let reset t = t.tat <- 0.0
+
+let time_until_ready t ~now =
+  let allow_at = t.tat -. t.burst_allowance in
+  Float.max 0.0 (allow_at -. now)
+
+let emission_interval t = t.emission_interval
+let burst_allowance t = t.burst_allowance

--- a/lib/rate_limiter/gcra.mli
+++ b/lib/rate_limiter/gcra.mli
@@ -1,0 +1,42 @@
+(** Generic Cell Rate Algorithm (GCRA) for rate limiting.
+
+    GCRA tracks a theoretical arrival time (TAT) for the next request. It
+    provides fair rate limiting with configurable burst capacity.
+
+    For a limit of N requests per T seconds:
+    - Sustained rate: N/T requests per second
+    - Burst capacity: N requests (the full quota can be used immediately)
+
+    The algorithm ensures that over any T-second window, no more than N requests
+    are allowed, while permitting short bursts when there's available quota. *)
+
+type t
+(** GCRA state for a single limit *)
+
+val create : Types.limit_config -> t
+(** Create a new GCRA state from a limit configuration *)
+
+val check : t -> now:float -> (unit, float) result
+(** Check if a request is allowed at the given time.
+    @param now Current time in seconds (e.g., from [Eio.Time.now])
+    @return [Ok ()] if allowed, [Error retry_after] if rate limited *)
+
+val update : t -> now:float -> unit
+(** Update state after a request is allowed. Must be called after [check]
+    returns [Ok ()] and before releasing any locks. *)
+
+val check_and_update : t -> now:float -> (unit, float) result
+(** Combined check and update. Atomically checks if allowed and updates state.
+    @return [Ok ()] if allowed, [Error retry_after] if rate limited *)
+
+val reset : t -> unit
+(** Reset the state (for testing) *)
+
+val time_until_ready : t -> now:float -> float
+(** Calculate seconds until the next request can proceed *)
+
+val emission_interval : t -> float
+(** Get the emission interval (time between requests at sustained rate) *)
+
+val burst_allowance : t -> float
+(** Get the burst allowance in seconds *)

--- a/lib/rate_limiter/matcher.ml
+++ b/lib/rate_limiter/matcher.ml
@@ -1,0 +1,47 @@
+(** Route matching for rate limiting. *)
+
+let path_matches_prefix ~path ~prefix =
+  if String.length prefix = 0 || prefix = "/" then true
+  else
+    (* Normalize: remove trailing slash from prefix for comparison *)
+    let normalized_prefix =
+      if String.ends_with ~suffix:"/" prefix then
+        String.sub prefix 0 (String.length prefix - 1)
+      else prefix
+    in
+    let prefix_len = String.length normalized_prefix in
+    let path_len = String.length path in
+    if String.starts_with ~prefix:normalized_prefix path then
+      (* Exact match or followed by '/' or end of path *)
+      prefix_len = path_len || (prefix_len < path_len && path.[prefix_len] = '/')
+    else false
+
+let matches_pattern ~method_ ~uri (pattern : Types.route_pattern) =
+  let host_matches =
+    match pattern.host with None -> true | Some h -> Uri.host uri = Some h
+  in
+  let method_matches =
+    match pattern.method_ with
+    | None -> true
+    | Some m -> String.uppercase_ascii m = String.uppercase_ascii method_
+  in
+  let path_matches =
+    match pattern.path_prefix with
+    | None -> true
+    | Some prefix ->
+        let path = Uri.path uri in
+        path_matches_prefix ~path ~prefix
+  in
+  host_matches && method_matches && path_matches
+
+let find_matching_routes ~method_ ~uri routes =
+  List.filter
+    (fun (rc : Types.route_config) -> matches_pattern ~method_ ~uri rc.pattern)
+    routes
+
+let make_route_key ~method_ ~uri (pattern : Types.route_pattern) =
+  let host = Option.value ~default:"*" (Uri.host uri) in
+  let path = Option.value ~default:"/" pattern.path_prefix in
+  (* Use pattern.method_ if specified, otherwise use actual request method *)
+  let method_str = Option.value ~default:method_ pattern.method_ in
+  Printf.sprintf "%s:%s:%s" host method_str path

--- a/lib/rate_limiter/matcher.mli
+++ b/lib/rate_limiter/matcher.mli
@@ -1,0 +1,31 @@
+(** Route matching for rate limiting.
+
+    This module provides pattern matching for HTTP requests against route
+    configurations. Pattern matching uses segment boundaries for paths, not
+    simple prefix matching. *)
+
+val matches_pattern : method_:string -> uri:Uri.t -> Types.route_pattern -> bool
+(** Check if a request matches a route pattern.
+    @param method_ HTTP method (e.g., "GET", "POST")
+    @param uri Request URI *)
+
+val find_matching_routes :
+  method_:string ->
+  uri:Uri.t ->
+  Types.route_config list ->
+  Types.route_config list
+(** Find all route configs that match the request. Routes are returned in the
+    order they appear in the config list. All matching routes apply (not just
+    first match). *)
+
+val make_route_key :
+  method_:string -> uri:Uri.t -> Types.route_pattern -> State.route_key
+(** Generate a unique key for state lookup. The key format is:
+    "host:method:path_prefix" *)
+
+val path_matches_prefix : path:string -> prefix:string -> bool
+(** Check if a path matches a prefix using segment boundaries. Examples:
+    - ["/orders"] matches ["/orders"], ["/orders/"], ["/orders/123"]
+    - ["/orders"] does NOT match ["/orders-test"], ["/ordersX"]
+    - ["/api/v1"] matches ["/api/v1/users"]
+    - ["/api/v1"] does NOT match ["/api/v10"] *)

--- a/lib/rate_limiter/presets.ml
+++ b/lib/rate_limiter/presets.ml
@@ -1,0 +1,166 @@
+(** Pre-configured rate limit presets for Polymarket APIs.
+
+    Based on official documentation:
+    https://docs.polymarket.com/#/api-rate-limits
+
+    This module is internal and not exposed to library users. *)
+
+module B = Builder
+
+(* {1 General Rate Limits} *)
+
+let general ~behavior =
+  [ B.global ~requests:15000 ~window_seconds:10.0 ~behavior ]
+
+(* {1 Data API Rate Limits} *)
+
+let data_api_host = "data-api.polymarket.com"
+
+let data_api ~behavior =
+  [
+    (* Specific endpoints first *)
+    B.per_endpoint ~host:data_api_host ~method_:"GET" ~path:"/trades"
+      ~requests:200 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:data_api_host ~method_:"GET" ~path:"/positions"
+      ~requests:150 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:data_api_host ~method_:"GET" ~path:"/closed-positions"
+      ~requests:150 ~window_seconds:10.0 ~behavior;
+    (* General Data API limit *)
+    B.per_host ~host:data_api_host ~requests:1000 ~window_seconds:10.0 ~behavior;
+  ]
+
+(* {1 Gamma API Rate Limits} *)
+
+let gamma_api_host = "gamma-api.polymarket.com"
+
+let gamma_api ~behavior =
+  [
+    (* Specific endpoints first *)
+    B.per_endpoint ~host:gamma_api_host ~method_:"GET" ~path:"/comments"
+      ~requests:200 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:gamma_api_host ~method_:"GET" ~path:"/events"
+      ~requests:300 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:gamma_api_host ~method_:"GET" ~path:"/markets"
+      ~requests:300 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:gamma_api_host ~method_:"GET" ~path:"/tags"
+      ~requests:200 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:gamma_api_host ~method_:"GET" ~path:"/search"
+      ~requests:300 ~window_seconds:10.0 ~behavior;
+    (* General Gamma API limit *)
+    B.per_host ~host:gamma_api_host ~requests:4000 ~window_seconds:10.0
+      ~behavior;
+  ]
+
+(* {1 CLOB API Rate Limits} *)
+
+let clob_api_host = "clob.polymarket.com"
+
+(* CLOB Trading endpoints with burst + sustained limits *)
+let clob_trading ~behavior =
+  [
+    (* POST /order: 3500/10s burst, 36000/10min sustained *)
+    B.(
+      route () |> host clob_api_host |> method_ "POST" |> path "/order"
+      |> limit ~requests:3500 ~window_seconds:10.0
+      |> limit ~requests:36000 ~window_seconds:600.0
+      |> on_limit behavior |> build);
+    (* DELETE /order: 3000/10s burst, 30000/10min sustained *)
+    B.(
+      route () |> host clob_api_host |> method_ "DELETE" |> path "/order"
+      |> limit ~requests:3000 ~window_seconds:10.0
+      |> limit ~requests:30000 ~window_seconds:600.0
+      |> on_limit behavior |> build);
+    (* POST /orders: 1000/10s burst, 15000/10min sustained *)
+    B.(
+      route () |> host clob_api_host |> method_ "POST" |> path "/orders"
+      |> limit ~requests:1000 ~window_seconds:10.0
+      |> limit ~requests:15000 ~window_seconds:600.0
+      |> on_limit behavior |> build);
+    (* DELETE /orders: 1000/10s burst, 15000/10min sustained *)
+    B.(
+      route () |> host clob_api_host |> method_ "DELETE" |> path "/orders"
+      |> limit ~requests:1000 ~window_seconds:10.0
+      |> limit ~requests:15000 ~window_seconds:600.0
+      |> on_limit behavior |> build);
+    (* DELETE /cancel-all: 250/10s burst, 6000/10min sustained *)
+    B.(
+      route () |> host clob_api_host |> method_ "DELETE" |> path "/cancel-all"
+      |> limit ~requests:250 ~window_seconds:10.0
+      |> limit ~requests:6000 ~window_seconds:600.0
+      |> on_limit behavior |> build);
+    (* DELETE /cancel-market-orders: 1000/10s burst, 1500/10min sustained *)
+    B.(
+      route () |> host clob_api_host |> method_ "DELETE"
+      |> path "/cancel-market-orders"
+      |> limit ~requests:1000 ~window_seconds:10.0
+      |> limit ~requests:1500 ~window_seconds:600.0
+      |> on_limit behavior |> build);
+  ]
+
+(* CLOB Market Data endpoints *)
+let clob_market_data ~behavior =
+  [
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/book"
+      ~requests:1500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/books"
+      ~requests:500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/price"
+      ~requests:1500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/prices"
+      ~requests:500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/midprice"
+      ~requests:1500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/midprices"
+      ~requests:500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/prices-history"
+      ~requests:1000 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/tick-size"
+      ~requests:200 ~window_seconds:10.0 ~behavior;
+  ]
+
+(* CLOB Ledger endpoints *)
+let clob_ledger ~behavior =
+  [
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/data/orders"
+      ~requests:500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/data/trades"
+      ~requests:500 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/notifications"
+      ~requests:125 ~window_seconds:10.0 ~behavior;
+    (* General ledger endpoints: /trades, /orders, /order *)
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/trades"
+      ~requests:900 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/orders"
+      ~requests:900 ~window_seconds:10.0 ~behavior;
+  ]
+
+(* CLOB Balance and Auth endpoints *)
+let clob_other ~behavior =
+  [
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/balance-allowance"
+      ~requests:200 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"POST"
+      ~path:"/balance-allowance" ~requests:50 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"GET" ~path:"/api-keys"
+      ~requests:100 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"POST" ~path:"/api-keys"
+      ~requests:100 ~window_seconds:10.0 ~behavior;
+    B.per_endpoint ~host:clob_api_host ~method_:"DELETE" ~path:"/api-keys"
+      ~requests:100 ~window_seconds:10.0 ~behavior;
+  ]
+
+let clob_api ~behavior =
+  (* Trading endpoints first (most specific, with burst+sustained) *)
+  clob_trading ~behavior @ clob_market_data ~behavior @ clob_ledger ~behavior
+  @ clob_other ~behavior
+  @ [
+      (* General CLOB limit last *)
+      B.per_host ~host:clob_api_host ~requests:9000 ~window_seconds:10.0
+        ~behavior;
+    ]
+
+(* {1 Combined Presets} *)
+
+let all ~behavior =
+  data_api ~behavior @ gamma_api ~behavior @ clob_api ~behavior
+  @ general ~behavior

--- a/lib/rate_limiter/rate_limiter.ml
+++ b/lib/rate_limiter/rate_limiter.ml
@@ -1,0 +1,109 @@
+(** Route-based rate limiting for HTTP clients. *)
+
+(* Re-export core types *)
+type behavior = Types.behavior = Delay | Error
+
+type route_pattern = Types.route_pattern = {
+  host : string option;
+  method_ : string option;
+  path_prefix : string option;
+}
+
+type limit_config = Types.limit_config = {
+  requests : int;
+  window_seconds : float;
+}
+
+type route_config = Types.route_config = {
+  pattern : route_pattern;
+  limits : limit_config list;
+  behavior : behavior;
+}
+
+type error = Types.error =
+  | Rate_limited of { retry_after : float; route_key : string }
+
+(* Rate limiter state *)
+type t = {
+  mutable routes : route_config list;
+  routes_mutex : Eio.Mutex.t;
+  state : State.t;
+  sleep : float -> unit;
+}
+
+let create ~routes ~clock ?max_idle_time () =
+  let state = State.create ~clock ?max_idle_time () in
+  let sleep duration = Eio.Time.sleep clock duration in
+  let routes_mutex = Eio.Mutex.create () in
+  { routes; routes_mutex; state; sleep }
+
+let create_polymarket ~clock ?(behavior = Delay) ?max_idle_time () =
+  let routes = Presets.all ~behavior in
+  create ~routes ~clock ?max_idle_time ()
+
+let update_routes t routes =
+  Eio.Mutex.use_rw ~protect:true t.routes_mutex (fun () -> t.routes <- routes)
+
+(* Wait for rate limit slot with Delay behavior, retrying until successful *)
+let rec wait_for_slot t ~route_key ~limits =
+  match State.check_limits t.state ~route_key ~limits with
+  | Ok () -> ()
+  | Error retry ->
+      t.sleep retry;
+      wait_for_slot t ~route_key ~limits
+
+(* Check rate limits, returns None if allowed or Some error *)
+let check t ~method_ ~uri =
+  let matching =
+    Eio.Mutex.use_ro t.routes_mutex (fun () ->
+        Matcher.find_matching_routes ~method_ ~uri t.routes)
+  in
+  let rec check_routes routes max_error =
+    match routes with
+    | [] -> max_error
+    | (route : route_config) :: rest ->
+        let route_key = Matcher.make_route_key ~method_ ~uri route.pattern in
+        let result =
+          State.check_limits t.state ~route_key ~limits:route.limits
+        in
+        let new_max_error =
+          match (result, route.behavior, max_error) with
+          | Ok (), _, max_err -> max_err
+          | Error retry, Error, None ->
+              Some (Rate_limited { retry_after = retry; route_key })
+          | Error retry, Error, Some (Rate_limited prev) ->
+              Some
+                (Rate_limited
+                   {
+                     retry_after = Float.max retry prev.retry_after;
+                     route_key = prev.route_key;
+                   })
+          | Error _, Delay, _ ->
+              wait_for_slot t ~route_key ~limits:route.limits;
+              max_error
+        in
+        check_routes rest new_max_error
+  in
+  check_routes matching None
+
+exception Rate_limit_exceeded of error
+
+let before_request t ~method_ ~uri =
+  match check t ~method_ ~uri with
+  | None -> ()
+  | Some err -> raise (Rate_limit_exceeded err)
+
+let before_request_result t ~method_ ~uri =
+  match check t ~method_ ~uri with None -> Ok () | Some err -> Error err
+
+(* State management *)
+let cleanup t = State.cleanup t.state
+let state_count t = State.state_count t.state
+let reset t = State.reset t.state
+
+(* Sub-modules *)
+module Types = Types
+module Builder = Builder
+module Gcra = Gcra
+module State = State
+module Matcher = Matcher

--- a/lib/rate_limiter/rate_limiter.mli
+++ b/lib/rate_limiter/rate_limiter.mli
@@ -1,0 +1,125 @@
+(** Route-based rate limiting for HTTP clients.
+
+    This library provides GCRA-based rate limiting with route matching,
+    supporting multiple limits per route and configurable delay/error behaviors.
+
+    {2 Quick Start}
+
+    {[
+      (* Create a shared rate limiter with Polymarket API limits *)
+      let rate_limiter =
+        Rate_limiter.create_polymarket ~clock:(Eio.Stdenv.clock env) ()
+      in
+
+      (* Pass to all API clients *)
+      let gamma = Gamma.create ~sw ~net ~rate_limiter () in
+      let data = Data.create ~sw ~net ~rate_limiter () in
+    ]}
+
+    {2 Features}
+
+    - {b Route matching}: Match requests by host, HTTP method, and path prefix
+    - {b Multiple limits}: Stack burst and sustained limits on the same route
+    - {b GCRA algorithm}: Fair rate limiting using Generic Cell Rate Algorithm
+    - {b Configurable behavior}: Delay requests or return errors per route *)
+
+(** {1 Core Types} *)
+
+type behavior = Types.behavior =
+  | Delay
+  | Error  (** Behavior when rate limit is exceeded *)
+
+type route_pattern = Types.route_pattern = {
+  host : string option;
+  method_ : string option;
+  path_prefix : string option;
+}
+(** Route matching pattern *)
+
+type limit_config = Types.limit_config = {
+  requests : int;
+  window_seconds : float;
+}
+(** Rate limit configuration *)
+
+type route_config = Types.route_config = {
+  pattern : route_pattern;
+  limits : limit_config list;
+  behavior : behavior;
+}
+(** Complete route configuration *)
+
+type error = Types.error =
+  | Rate_limited of { retry_after : float; route_key : string }
+      (** Rate limiter error *)
+
+(** {1 Rate Limiter} *)
+
+type t
+(** Rate limiter state *)
+
+exception Rate_limit_exceeded of error
+(** Raised by [before_request] when behavior is [Error] and limit exceeded *)
+
+val create :
+  routes:route_config list ->
+  clock:_ Eio.Time.clock ->
+  ?max_idle_time:float ->
+  unit ->
+  t
+(** Create a rate limiter with custom routes.
+    @param routes Rate limit configurations (all matching routes apply)
+    @param clock Eio clock for timing and delays
+    @param max_idle_time
+      For cleanup: remove states unused for this long (default: 300.0) *)
+
+val create_polymarket :
+  clock:_ Eio.Time.clock ->
+  ?behavior:behavior ->
+  ?max_idle_time:float ->
+  unit ->
+  t
+(** Create a rate limiter with Polymarket API presets.
+
+    This is the recommended way to create a rate limiter for use with Polymarket
+    API clients. The rate limiter should be shared across all clients to
+    properly enforce global rate limits.
+
+    @param clock Eio clock for timing and delays
+    @param behavior What to do when rate limit is exceeded (default: Delay)
+    @param max_idle_time
+      For cleanup: remove states unused for this long (default: 300.0) *)
+
+val update_routes : t -> route_config list -> unit
+(** Update the rate limit routes at runtime *)
+
+val before_request : t -> method_:string -> uri:Uri.t -> unit
+(** Check rate limits before making a request.
+
+    - For [Delay] behavior: sleeps until the request is allowed
+    - For [Error] behavior: raises [Rate_limit_exceeded] if limit exceeded
+
+    @raise Rate_limit_exceeded when behavior is [Error] and limit exceeded *)
+
+val before_request_result :
+  t -> method_:string -> uri:Uri.t -> (unit, error) result
+(** Like [before_request] but returns a result instead of raising. *)
+
+(** {1 State Management} *)
+
+val cleanup : t -> unit
+(** Remove stale state entries (unused longer than max_idle_time) *)
+
+val state_count : t -> int
+(** Get the number of active state entries *)
+
+val reset : t -> unit
+(** Clear all rate limit state (for testing) *)
+
+(** {1 Sub-modules} *)
+
+module Types = Types
+module Builder = Builder
+module Gcra = Gcra
+module State = State
+module Matcher = Matcher

--- a/lib/rate_limiter/state.ml
+++ b/lib/rate_limiter/state.ml
@@ -1,0 +1,72 @@
+(** State management for rate limiting. *)
+
+type route_key = string
+type state_entry = { gcras : Gcra.t list; mutable last_used : float }
+
+type t = {
+  now : unit -> float;
+  table : (route_key, state_entry) Hashtbl.t;
+  mutex : Eio.Mutex.t;
+  max_idle_time : float;
+}
+
+let create ~clock ?(max_idle_time = 300.0) () =
+  let table = Hashtbl.create 64 in
+  let mutex = Eio.Mutex.create () in
+  let now () = Eio.Time.now clock in
+  { now; table; mutex; max_idle_time }
+
+let get_or_create_entry t ~route_key ~limits =
+  let now_time = t.now () in
+  match Hashtbl.find_opt t.table route_key with
+  | Some entry ->
+      entry.last_used <- now_time;
+      entry
+  | None ->
+      let gcras = List.map Gcra.create limits in
+      let entry = { gcras; last_used = now_time } in
+      Hashtbl.add t.table route_key entry;
+      entry
+
+let check_limits t ~route_key ~limits =
+  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+      let now_time = t.now () in
+      let entry = get_or_create_entry t ~route_key ~limits in
+      (* Check all limits, collect maximum retry_after if any fail *)
+      let rec check_all gcras max_retry =
+        match gcras with
+        | [] -> (
+            match max_retry with
+            | None ->
+                (* All passed, update all states *)
+                List.iter
+                  (fun gcra -> Gcra.update gcra ~now:now_time)
+                  entry.gcras;
+                Ok ()
+            | Some retry -> Error retry)
+        | gcra :: rest -> (
+            match Gcra.check gcra ~now:now_time with
+            | Ok () -> check_all rest max_retry
+            | Error retry ->
+                let new_max =
+                  match max_retry with
+                  | None -> Some retry
+                  | Some prev -> Some (Float.max prev retry)
+                in
+                check_all rest new_max)
+      in
+      check_all entry.gcras None)
+
+let cleanup t =
+  let now_time = t.now () in
+  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+      Hashtbl.filter_map_inplace
+        (fun _key entry ->
+          if now_time -. entry.last_used > t.max_idle_time then None
+          else Some entry)
+        t.table)
+
+let state_count t = Eio.Mutex.use_ro t.mutex (fun () -> Hashtbl.length t.table)
+
+let reset t =
+  Eio.Mutex.use_rw ~protect:true t.mutex (fun () -> Hashtbl.clear t.table)

--- a/lib/rate_limiter/state.mli
+++ b/lib/rate_limiter/state.mli
@@ -1,0 +1,35 @@
+(** State management for rate limiting.
+
+    This module manages GCRA states for all routes, providing thread-safe
+    access. Call [cleanup] explicitly to remove stale entries. *)
+
+type t
+(** State manager for all route limits *)
+
+type route_key = string
+(** Unique key identifying a route (e.g., "api.example.com:GET:/orders") *)
+
+val create : clock:_ Eio.Time.clock -> ?max_idle_time:float -> unit -> t
+(** Create a state manager.
+    @param clock Eio clock for timing
+    @param max_idle_time
+      Remove states unused for this long in seconds (default: 300.0) *)
+
+val check_limits :
+  t ->
+  route_key:route_key ->
+  limits:Types.limit_config list ->
+  (unit, float) result
+(** Check all limits for a route.
+    @return
+      [Ok ()] if all limits pass, [Error max_retry_after] if any limit is
+      exceeded *)
+
+val cleanup : t -> unit
+(** Remove stale state entries (unused longer than max_idle_time) *)
+
+val state_count : t -> int
+(** Get the number of active state entries (for monitoring) *)
+
+val reset : t -> unit
+(** Clear all state (for testing) *)

--- a/lib/rate_limiter/types.ml
+++ b/lib/rate_limiter/types.ml
@@ -1,0 +1,27 @@
+(** Core types for rate limiting. *)
+
+type route_pattern = {
+  host : string option;
+  method_ : string option;
+  path_prefix : string option;
+}
+[@@deriving show, eq]
+
+let any_route = { host = None; method_ = None; path_prefix = None }
+
+type limit_config = { requests : int; window_seconds : float }
+[@@deriving show, eq]
+
+let limit ~requests ~window_seconds = { requests; window_seconds }
+
+type behavior = Delay | Error [@@deriving show, eq]
+
+type route_config = {
+  pattern : route_pattern;
+  limits : limit_config list;
+  behavior : behavior;
+}
+[@@deriving show, eq]
+
+type error = Rate_limited of { retry_after : float; route_key : string }
+[@@deriving show, eq]

--- a/lib/rate_limiter/types.mli
+++ b/lib/rate_limiter/types.mli
@@ -1,0 +1,63 @@
+(** Core types for rate limiting.
+
+    This module defines the configuration types used throughout the rate
+    limiter. *)
+
+(** {1 Route Patterns}
+
+    Route patterns match HTTP requests by host, method, and path prefix. All
+    fields are optional - unspecified fields match any value. *)
+
+type route_pattern = {
+  host : string option;  (** Hostname to match (e.g., "api.example.com") *)
+  method_ : string option;  (** HTTP method to match (e.g., "GET", "POST") *)
+  path_prefix : string option;
+      (** Path prefix to match (e.g., "/api/v1"). Uses segment boundaries. *)
+}
+[@@deriving show, eq]
+
+val any_route : route_pattern
+(** Pattern matching all routes *)
+
+(** {1 Limit Configuration}
+
+    GCRA-based rate limit configuration using requests per time window. *)
+
+type limit_config = {
+  requests : int;  (** Number of requests allowed in the window *)
+  window_seconds : float;  (** Time window in seconds *)
+}
+[@@deriving show, eq]
+
+val limit : requests:int -> window_seconds:float -> limit_config
+(** Create a limit configuration. Example:
+    [limit ~requests:100 ~window_seconds:10.0] for 100 req/10s *)
+
+(** {1 Behavior}
+
+    What to do when a request exceeds the rate limit. *)
+
+type behavior =
+  | Delay  (** Sleep until the request can proceed *)
+  | Error  (** Return an error immediately *)
+[@@deriving show, eq]
+
+(** {1 Route Configuration}
+
+    Complete configuration for a rate-limited route. *)
+
+type route_config = {
+  pattern : route_pattern;  (** Which requests this route matches *)
+  limits : limit_config list;  (** Rate limits to apply (all must pass) *)
+  behavior : behavior;  (** What to do when rate limited *)
+}
+[@@deriving show, eq]
+
+(** {1 Errors} *)
+
+type error =
+  | Rate_limited of {
+      retry_after : float;  (** Seconds until request can proceed *)
+      route_key : string;  (** The route that was rate limited *)
+    }
+[@@deriving show, eq]


### PR DESCRIPTION
- Add new rate_limiter library with GCRA algorithm
- Support route-based rate limiting with host/method/path matching
- Include Polymarket API rate limit presets (Data, Gamma, CLOB)
- Update all API clients to require shared rate_limiter parameter
- Add Rate_limiter.create_polymarket convenience function
- Update examples to demonstrate shared rate limiter usage

Resolves #11 