### PR TITLE
fix: improve HTTP client error handling and logging

### DIFF
--- a/examples/logger.ml
+++ b/examples/logger.ml
@@ -40,7 +40,6 @@ let make_reporter ppf =
 let log_channel = ref None
 
 let setup () =
-  Logs.set_level None;
   let reporter =
     match Sys.getenv_opt "POLYMARKET_LOG_FILE" with
     | Some path ->
@@ -50,7 +49,9 @@ let setup () =
     | None -> make_reporter Format.std_formatter
   in
   Logs.set_reporter reporter;
-  Logs.Src.set_level src (Some Logs.Debug)
+  Logs.Src.set_level src (Some Logs.Debug);
+  (* Also initialize the polymarket library logger to respect POLYMARKET_LOG_LEVEL *)
+  Polymarket_common.Logger.setup ()
 
 let close () =
   match !log_channel with

--- a/lib/data_api/types.ml
+++ b/lib/data_api/types.ml
@@ -370,7 +370,7 @@ type value = { user : Polymarket_common.Primitives.Address.t; value : float }
 (** Value record *)
 
 type open_interest = {
-  market : Polymarket_common.Primitives.Hash64.t;
+  market : string;  (** Can be "GLOBAL" or a condition ID hash *)
   value : float;
 }
 [@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]

--- a/lib/data_api/types.mli
+++ b/lib/data_api/types.mli
@@ -258,7 +258,7 @@ type value = { user : Polymarket_common.Primitives.Address.t; value : float }
 (** Value record *)
 
 type open_interest = {
-  market : Polymarket_common.Primitives.Hash64.t;
+  market : string;  (** Can be "GLOBAL" or a condition ID hash *)
   value : float;
 }
 [@@deriving yojson, show, eq]


### PR DESCRIPTION
- Catch all exceptions in parse_json/parse_json_list, not just yojson errors
- Log parse errors before returning them as Error results
- Initialize polymarket logger in demo setup for debug output
- Change open_interest.market from Hash64.t to string (API returns "GLOBAL")
