### PR TITLE
fix: WebSocket client connection and message parsing improvements

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -12,3 +12,8 @@
  (name clob_api_demo)
  (modules clob_api_demo logger)
  (libraries polymarket unix eio_main mirage-crypto-rng.unix logs))
+
+(executable
+ (name wss_demo)
+ (modules wss_demo logger)
+ (libraries polymarket unix eio_main mirage-crypto-rng.unix logs))

--- a/examples/wss_demo.ml
+++ b/examples/wss_demo.ml
@@ -1,0 +1,82 @@
+(** Live demo of the Polymarket WebSocket client.
+
+    This example connects to the Market WebSocket channel and watches for
+    real-time price updates on the BTC 15-minute up/down market. Run with: dune
+    exec examples/wss_demo.exe
+
+    Set POLYMARKET_LOG_LEVEL=debug for verbose output. *)
+
+open Polymarket
+
+(** BTC 15-minute up/down market token IDs (11:15AM-11:30AM ET) *)
+let btc_15m_tokens =
+  [
+    "26060244286464519668811473204271758681039108505277070711042957949579613021410";
+    "82687937324480524188563760165060496550572104948772493241341448161316962449821";
+  ]
+
+(** Format a market message for display *)
+let format_message = function
+  | Wss.Types.Market (Book msg) ->
+      Printf.sprintf "[BOOK] asset=%s bids=%d asks=%d"
+        (String.sub msg.asset_id 0 (min 16 (String.length msg.asset_id)))
+        (List.length msg.bids) (List.length msg.asks)
+  | Wss.Types.Market (Price_change msg) ->
+      Printf.sprintf "[PRICE] market=%s changes=%d"
+        (String.sub msg.market 0 (min 16 (String.length msg.market)))
+        (List.length msg.price_changes)
+  | Wss.Types.Market (Last_trade_price msg) ->
+      Printf.sprintf "[TRADE] price=%s size=%s side=%s" msg.price msg.size
+        msg.side
+  | Wss.Types.Market (Tick_size_change msg) ->
+      Printf.sprintf "[TICK] old=%s new=%s" msg.old_tick_size msg.new_tick_size
+  | Wss.Types.Market (Best_bid_ask msg) ->
+      Printf.sprintf "[BBA] bid=%s ask=%s" msg.best_bid msg.best_ask
+  | Wss.Types.User _ -> "[USER] (unexpected)"
+  | Wss.Types.Unknown raw ->
+      Printf.sprintf "[UNKNOWN] %s"
+        (String.sub raw 0 (min 50 (String.length raw)))
+
+let run_demo env =
+  Logger.setup ();
+  Eio.Switch.run @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+
+  Logger.info "START" [ ("demo", "WebSocket Market Stream") ];
+  Logger.header "BTC 15-minute Up/Down Market";
+
+  (* Connect to market channel with BTC 15m tokens *)
+  let market_client =
+    Wss.Market.connect ~sw ~net ~asset_ids:btc_15m_tokens ()
+  in
+  let stream = Wss.Market.stream market_client in
+
+  Logger.header "Watching Messages (Ctrl+C to stop)";
+
+  (* Watch for messages *)
+  let count = ref 0 in
+  (try
+     while true do
+       let msg = Eio.Stream.take stream in
+       incr count;
+       let formatted = format_message msg in
+       Logger.info "MSG" [ ("n", string_of_int !count); ("data", formatted) ];
+       (* Stop after 50 messages for demo purposes *)
+       if !count >= 50 then begin
+         Logger.info "LIMIT" [ ("message", "reached 50 messages, stopping") ];
+         raise Exit
+       end
+     done
+   with
+  | Exit -> ()
+  | Eio.Cancel.Cancelled _ -> Logger.info "CANCELLED" []);
+
+  (* Cleanup *)
+  Wss.Market.close market_client;
+  Logger.header "Summary";
+  Logger.info "COMPLETE" [ ("messages_received", string_of_int !count) ]
+
+let () =
+  Mirage_crypto_rng_unix.use_default ();
+  Eio_main.run run_demo;
+  Logger.close ()

--- a/lib/common/logger.ml
+++ b/lib/common/logger.ml
@@ -37,7 +37,9 @@ let setup () =
             None
         | some_level -> some_level)
   in
-  (* Only set the source level, don't override the reporter *)
+  (* Set default log level for all sources (including wss, etc) *)
+  Logs.set_level log_level;
+  (* Also set explicitly for this source *)
   Logs.Src.set_level src log_level
 
 (** {1 Structured Logging} *)

--- a/lib/wss_client/dune
+++ b/lib/wss_client/dune
@@ -14,6 +14,7 @@
   httpun
   httpun-ws
   httpun-ws-eio
+  gluten-eio
   digestif
   logs)
  (preprocess

--- a/lib/wss_client/types.mli
+++ b/lib/wss_client/types.mli
@@ -27,7 +27,12 @@ val equal_order_summary : order_summary -> order_summary -> bool
 (** {1 Market Channel Message Types} *)
 
 module Market_event : sig
-  type t = Book | Price_change | Tick_size_change | Last_trade_price
+  type t =
+    | Book
+    | Price_change
+    | Tick_size_change
+    | Last_trade_price
+    | Best_bid_ask
 
   val to_string : t -> string
   val of_string : string -> t
@@ -138,6 +143,24 @@ val show_last_trade_price_message : last_trade_price_message -> string
 
 val equal_last_trade_price_message :
   last_trade_price_message -> last_trade_price_message -> bool
+
+type best_bid_ask_message = {
+  event_type : string;
+  asset_id : string;
+  market : string;
+  best_bid : string;
+  best_ask : string;
+  timestamp : string;
+}
+(** Best bid/ask message *)
+
+val best_bid_ask_message_of_yojson : Yojson.Safe.t -> best_bid_ask_message
+val yojson_of_best_bid_ask_message : best_bid_ask_message -> Yojson.Safe.t
+val pp_best_bid_ask_message : Format.formatter -> best_bid_ask_message -> unit
+val show_best_bid_ask_message : best_bid_ask_message -> string
+
+val equal_best_bid_ask_message :
+  best_bid_ask_message -> best_bid_ask_message -> bool
 
 (** {1 User Channel Message Types} *)
 
@@ -251,6 +274,7 @@ type market_message =
   | Price_change of price_change_message
   | Tick_size_change of tick_size_change_message
   | Last_trade_price of last_trade_price_message
+  | Best_bid_ask of best_bid_ask_message
 
 val pp_market_message : Format.formatter -> market_message -> unit
 val show_market_message : market_message -> string
@@ -279,9 +303,10 @@ val parse_market_message : Yojson.Safe.t -> market_message
 val parse_user_message : Yojson.Safe.t -> user_message
 (** Parse a JSON value as a user channel message. *)
 
-val parse_message : channel:Channel.t -> string -> message
-(** Parse a raw JSON string into a typed message based on channel. Returns
-    [Unknown] if parsing fails. *)
+val parse_message : channel:Channel.t -> string -> message list
+(** Parse a raw JSON string into typed messages based on channel. Returns empty
+    list for ack messages, handles arrays of messages from initial subscription.
+*)
 
 (** {1 Subscription Requests} *)
 


### PR DESCRIPTION
- Fix ALPN negotiation to ensure HTTP/1.1 for WebSocket upgrade
- Handle multi-chunk payloads with recursive schedule_read
- Parse message arrays from initial subscription response
- Add best_bid_ask message type support
- Add allow_extra_fields to all message types for forward compatibility
- Fix subscription format: uppercase type, add custom_feature_enabled
- Add wss_demo example for real-time market streaming
- Expose Wss module in main library interface