### PR TITLE
refactor: use structured logging in WSS client

### DIFF
--- a/lib/common/logger.ml
+++ b/lib/common/logger.ml
@@ -37,10 +37,16 @@ let setup () =
             None
         | some_level -> some_level)
   in
-  (* Set default log level for all sources (including wss, etc) *)
-  Logs.set_level log_level;
-  (* Also set explicitly for this source *)
-  Logs.Src.set_level src log_level
+  (* Only set log level for our sources, not globally (to avoid third-party noise) *)
+  Logs.Src.set_level src log_level;
+  (* Also set for WSS sources *)
+  List.iter
+    (fun s ->
+      if
+        String.length (Logs.Src.name s) >= 11
+        && String.sub (Logs.Src.name s) 0 11 = "polymarket."
+      then Logs.Src.set_level s log_level)
+    (Logs.Src.list ())
 
 (** {1 Structured Logging} *)
 


### PR DESCRIPTION
- Switch WSS connection and client to use common Logger module
- Update log format to [SECTION] [EVENT] key="value" pairs
- Fix logger setup to only set levels for polymarket sources, avoiding third-party noise
- Update wss_demo to use structured logging for message output
