### PR TITLE
feat: add WebSocket client with pure-OCaml TLS

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -12,3 +12,8 @@
  (name clob_api_demo)
  (modules clob_api_demo logger)
  (libraries polymarket unix eio_main mirage-crypto-rng.unix logs))
+
+(executable
+ (name wss_demo)
+ (modules wss_demo logger)
+ (libraries polymarket unix eio_main mirage-crypto-rng.unix logs yojson))

--- a/lib/dune
+++ b/lib/dune
@@ -7,4 +7,5 @@
   polymarket_rate_limiter
   polymarket_clob
   polymarket_data
-  polymarket_gamma))
+  polymarket_gamma
+  polymarket_wss))

--- a/lib/polymarket.ml
+++ b/lib/polymarket.ml
@@ -50,6 +50,16 @@ module Clob = struct
   let l1_to_unauthed = Polymarket_clob.Client.l1_to_unauthed
 end
 
+module Wss = struct
+  (** WebSocket client for real-time market and user data.
+
+      Uses pure-OCaml TLS (tls-eio) for cross-platform compatibility. *)
+
+  module Types = Polymarket_wss.Types
+  module Market = Polymarket_wss.Client.Market
+  module User = Polymarket_wss.Client.User
+end
+
 module Http = Polymarket_http.Client
 (** HTTP client utilities for making API requests. *)
 

--- a/lib/polymarket.mli
+++ b/lib/polymarket.mli
@@ -156,6 +156,54 @@ module Clob : sig
   val l1_to_unauthed : l1 -> unauthed
 end
 
+module Wss : sig
+  (** WebSocket client for real-time market and user data.
+
+      Uses pure-OCaml TLS (tls-eio) for cross-platform compatibility.
+
+      {2 Market Channel (Public)}
+
+      Subscribe to orderbook updates for specific asset IDs:
+
+      {[
+        Eio_main.run @@ fun env ->
+        Eio.Switch.run @@ fun sw ->
+        let net = Eio.Stdenv.net env in
+        let clock = Eio.Stdenv.clock env in
+        let asset_ids = [ "token_id_1"; "token_id_2" ] in
+        let client = Wss.Market.connect ~sw ~net ~clock ~asset_ids () in
+        let stream = Wss.Market.stream client in
+        match Eio.Stream.take stream with
+        | Wss.Types.Market (Book msg) ->
+            Printf.printf "Book update for %s\n" msg.asset_id
+        | _ -> ()
+      ]}
+
+      {2 User Channel (Authenticated)}
+
+      Subscribe to your trades and orders with API credentials:
+
+      {[
+        let credentials =
+          Clob.Auth_types.
+            { api_key = "..."; secret = "..."; passphrase = "..." }
+        in
+        let markets = [ "condition_id_1" ] in
+        let client =
+          Wss.User.connect ~sw ~net ~clock ~credentials ~markets ()
+        in
+        let stream = Wss.User.stream client in
+        match Eio.Stream.take stream with
+        | Wss.Types.User (Trade msg) ->
+            Printf.printf "Trade: %s at %s\n" msg.id msg.price
+        | _ -> ()
+      ]} *)
+
+  module Types = Polymarket_wss.Types
+  module Market = Polymarket_wss.Client.Market
+  module User = Polymarket_wss.Client.User
+end
+
 module Http = Polymarket_http.Client
 (** HTTP client utilities for making API requests. *)
 

--- a/lib/websocket_client/client.ml
+++ b/lib/websocket_client/client.ml
@@ -1,0 +1,120 @@
+(** High-level WebSocket client for Polymarket.
+
+    Provides typed streaming access to Market and User channels. *)
+
+module Logger = Polymarket_common.Logger
+
+let section = "WSS"
+
+(** Polymarket WebSocket host *)
+let default_host = "ws-subscriptions-clob.polymarket.com"
+
+(** {1 Market Channel Client} *)
+
+module Market = struct
+  type t = {
+    conn : Connection.t;
+    message_stream : Types.message Eio.Stream.t;
+    mutable asset_ids : string list;
+  }
+
+  let connect ~sw ~net ~clock ~asset_ids () =
+    let conn =
+      Connection.create ~sw ~net ~clock ~host:default_host
+        ~resource:"/ws/market" ()
+    in
+    let message_stream = Eio.Stream.create 1000 in
+
+    (* Set subscription message for reconnection *)
+    let subscribe_msg = Types.market_subscribe_json ~asset_ids in
+    Connection.set_subscription conn subscribe_msg;
+
+    (* Start the connection *)
+    Connection.start conn;
+
+    (* Start message parsing fiber *)
+    Eio.Fiber.fork ~sw (fun () ->
+        try
+          let raw_stream = Connection.message_stream conn in
+          while not (Connection.is_closed conn) do
+            let raw = Eio.Stream.take raw_stream in
+            let msgs = Types.parse_message ~channel:Types.Channel.Market raw in
+            List.iter (fun msg -> Eio.Stream.add message_stream msg) msgs
+          done;
+          Logger.log_debug ~section ~event:"PARSER_STOPPED"
+            [ ("channel", "market") ]
+        with
+        | Eio.Cancel.Cancelled _ ->
+            Logger.log_debug ~section ~event:"PARSER_CANCELLED"
+              [ ("channel", "market") ]
+        | exn ->
+            Logger.log_err ~section ~event:"PARSER_ERROR"
+              [ ("channel", "market"); ("error", Printexc.to_string exn) ]);
+
+    { conn; message_stream; asset_ids }
+
+  let stream t = t.message_stream
+
+  let subscribe t ~asset_ids =
+    t.asset_ids <- t.asset_ids @ asset_ids;
+    let msg = Types.subscribe_assets_json ~asset_ids in
+    Connection.send t.conn msg;
+    (* Update stored subscription for reconnect *)
+    let full_msg = Types.market_subscribe_json ~asset_ids:t.asset_ids in
+    Connection.set_subscription t.conn full_msg
+
+  let unsubscribe t ~asset_ids =
+    t.asset_ids <-
+      List.filter (fun id -> not (List.mem id asset_ids)) t.asset_ids;
+    let msg = Types.unsubscribe_assets_json ~asset_ids in
+    Connection.send t.conn msg;
+    (* Update stored subscription for reconnect *)
+    let full_msg = Types.market_subscribe_json ~asset_ids:t.asset_ids in
+    Connection.set_subscription t.conn full_msg
+
+  let close t = Connection.close t.conn
+end
+
+(** {1 User Channel Client} *)
+
+module User = struct
+  type t = { conn : Connection.t; message_stream : Types.message Eio.Stream.t }
+
+  let connect ~sw ~net ~clock ~credentials ~markets () =
+    let conn =
+      Connection.create ~sw ~net ~clock ~host:default_host ~resource:"/ws/user"
+        ()
+    in
+    let message_stream = Eio.Stream.create 1000 in
+
+    (* Set subscription message with auth for reconnection *)
+    let subscribe_msg = Types.user_subscribe_json ~credentials ~markets in
+    Connection.set_subscription conn subscribe_msg;
+
+    (* Start the connection *)
+    Connection.start conn;
+
+    (* Start message parsing fiber *)
+    Eio.Fiber.fork ~sw (fun () ->
+        try
+          let raw_stream = Connection.message_stream conn in
+          while not (Connection.is_closed conn) do
+            let raw = Eio.Stream.take raw_stream in
+            let msgs = Types.parse_message ~channel:Types.Channel.User raw in
+            List.iter (fun msg -> Eio.Stream.add message_stream msg) msgs
+          done;
+          Logger.log_debug ~section ~event:"PARSER_STOPPED"
+            [ ("channel", "user") ]
+        with
+        | Eio.Cancel.Cancelled _ ->
+            Logger.log_debug ~section ~event:"PARSER_CANCELLED"
+              [ ("channel", "user") ]
+        | exn ->
+            Logger.log_err ~section ~event:"PARSER_ERROR"
+              [ ("channel", "user"); ("error", Printexc.to_string exn) ]);
+
+    { conn; message_stream }
+
+  let stream t = t.message_stream
+  let close t = Connection.close t.conn
+end

--- a/lib/websocket_client/connection.ml
+++ b/lib/websocket_client/connection.ml
@@ -1,0 +1,251 @@
+(** WebSocket connection management with TLS and reconnection support.
+
+    Uses tls-eio for pure-OCaml TLS, avoiding OpenSSL dependencies. *)
+
+module Logger = Polymarket_common.Logger
+
+let section = "WSS"
+
+(** Connection state *)
+type state = Disconnected | Connecting | Connected | Closing | Closed
+
+type config = {
+  host : string;
+  port : int;
+  resource : string;
+  initial_backoff : float;
+  max_backoff : float;
+  ping_interval : float;
+}
+(** Connection configuration *)
+
+let default_config ~host ~resource =
+  {
+    host;
+    port = 443;
+    resource;
+    initial_backoff = 1.0;
+    max_backoff = 60.0;
+    ping_interval = 30.0;
+  }
+
+(** Network wrapper to hide type parameter *)
+type net_t = Net : 'a Eio.Net.t -> net_t
+
+type t = {
+  config : config;
+  sw : Eio.Switch.t;
+  net : net_t;
+  clock : float Eio.Time.clock_ty Eio.Resource.t;
+  mutable state : state;
+  mutable flow : Tls_eio.t option;
+  message_stream : string Eio.Stream.t;
+  mutable subscription_msg : string option;
+  mutable closed : bool;
+  mutable current_backoff : float;
+}
+(** Internal connection type *)
+
+(** Create TLS configuration *)
+let make_tls_config () =
+  let authenticator =
+    match Ca_certs.authenticator () with
+    | Ok auth -> auth
+    | Error (`Msg msg) -> failwith ("CA certs error: " ^ msg)
+  in
+  match Tls.Config.client ~authenticator () with
+  | Ok cfg -> cfg
+  | Error (`Msg msg) -> failwith ("TLS config error: " ^ msg)
+
+(** Create a new connection *)
+let create ~sw ~net ~clock ~host ~resource () =
+  {
+    config = default_config ~host ~resource;
+    sw;
+    net = Net net;
+    clock;
+    state = Disconnected;
+    flow = None;
+    message_stream = Eio.Stream.create 1000;
+    subscription_msg = None;
+    closed = false;
+    current_backoff = 1.0;
+  }
+
+(** Establish TCP + TLS connection *)
+let connect_tls t =
+  let host = t.config.host in
+  let port = t.config.port in
+  let (Net net) = t.net in
+
+  Logger.log_info ~section ~event:"TCP_CONNECT"
+    [ ("host", host); ("port", string_of_int port) ];
+
+  (* Resolve address *)
+  let addr =
+    match Eio.Net.getaddrinfo_stream net host ~service:(string_of_int port) with
+    | [] -> failwith ("Failed to resolve host: " ^ host)
+    | addr :: _ -> addr
+  in
+
+  (* Connect TCP *)
+  let socket = Eio.Net.connect ~sw:t.sw net addr in
+
+  (* Upgrade to TLS *)
+  let tls_config = make_tls_config () in
+  let host_name = Domain_name.of_string_exn host |> Domain_name.host_exn in
+  Logger.log_debug ~section ~event:"TLS_HANDSHAKE" [];
+  let tls_flow = Tls_eio.client_of_flow tls_config ~host:host_name socket in
+  Logger.log_info ~section ~event:"TLS_CONNECTED" [];
+
+  tls_flow
+
+(** Connect and perform WebSocket handshake *)
+let connect_internal t =
+  t.state <- Connecting;
+  let flow = connect_tls t in
+
+  (* Perform WebSocket handshake *)
+  match
+    Handshake.perform ~flow ~host:t.config.host ~port:t.config.port
+      ~resource:t.config.resource
+  with
+  | Handshake.Success ->
+      t.flow <- Some flow;
+      t.state <- Connected;
+      t.current_backoff <- t.config.initial_backoff;
+      Logger.log_info ~section ~event:"CONNECTED" [];
+      true
+  | Handshake.Failed msg ->
+      Logger.log_err ~section ~event:"HANDSHAKE_FAILED" [ ("error", msg) ];
+      t.state <- Disconnected;
+      false
+
+(** Send a frame *)
+let send_frame t frame =
+  match t.flow with
+  | Some flow ->
+      let data = Frame.encode ~mask:true frame in
+      Eio.Flow.copy_string data flow;
+      Logger.log_debug ~section ~event:"FRAME_SENT"
+        [ ("opcode", string_of_int (Frame.Opcode.to_int frame.opcode)) ]
+  | None ->
+      Logger.log_warn ~section ~event:"SEND_FAILED"
+        [ ("reason", "not connected") ]
+
+(** Send a text message *)
+let send t msg =
+  send_frame t (Frame.text msg);
+  Logger.log_debug ~section ~event:"MSG_SENT" [ ("msg", msg) ]
+
+(** Send a ping *)
+let send_ping t = send_frame t (Frame.ping ())
+
+(** Receive loop - reads frames and dispatches to message stream *)
+let receive_loop t =
+  match t.flow with
+  | None -> ()
+  | Some flow -> (
+      try
+        while t.state = Connected do
+          let frame = Frame.decode flow in
+          match frame.opcode with
+          | Frame.Opcode.Text | Frame.Opcode.Binary ->
+              Eio.Stream.add t.message_stream frame.payload
+          | Frame.Opcode.Ping ->
+              (* Respond with pong *)
+              send_frame t (Frame.pong ~payload:frame.payload ());
+              Logger.log_debug ~section ~event:"PING_RECV" []
+          | Frame.Opcode.Pong -> Logger.log_debug ~section ~event:"PONG_RECV" []
+          | Frame.Opcode.Close ->
+              Logger.log_info ~section ~event:"CLOSE_RECV" [];
+              t.state <- Closed
+          | _ -> ()
+        done
+      with
+      | End_of_file ->
+          Logger.log_info ~section ~event:"EOF" [];
+          t.state <- Disconnected
+      | exn ->
+          Logger.log_err ~section ~event:"RECV_ERROR"
+            [ ("error", Printexc.to_string exn) ];
+          t.state <- Disconnected)
+
+(** Ping loop - sends periodic pings *)
+let ping_loop t =
+  try
+    while t.state = Connected && not t.closed do
+      Eio.Time.sleep t.clock t.config.ping_interval;
+      if t.state = Connected then begin
+        send_ping t;
+        Logger.log_debug ~section ~event:"PING_SENT" []
+      end
+    done
+  with
+  | Eio.Cancel.Cancelled _ ->
+      Logger.log_debug ~section ~event:"PING_CANCELLED" []
+  | _ -> ()
+
+(** Connect with exponential backoff retry *)
+let rec connect_with_retry t =
+  if t.closed then ()
+  else if connect_internal t then begin
+    (* Send subscription message if set *)
+    match t.subscription_msg with
+    | Some msg ->
+        send t msg;
+        Logger.log_info ~section ~event:"RESUBSCRIBED" []
+    | None -> ()
+  end
+  else begin
+    Logger.log_warn ~section ~event:"RETRY"
+      [ ("backoff", Printf.sprintf "%.1fs" t.current_backoff) ];
+    Eio.Time.sleep t.clock t.current_backoff;
+    t.current_backoff <- min (t.current_backoff *. 2.0) t.config.max_backoff;
+    connect_with_retry t
+  end
+
+(** Set subscription message for reconnection *)
+let set_subscription t msg = t.subscription_msg <- Some msg
+
+(** Get message stream *)
+let message_stream t = t.message_stream
+
+(** Check if connected *)
+let is_connected t = t.state = Connected
+
+(** Check if closed *)
+let is_closed t = t.closed
+
+(** Close connection *)
+let close t =
+  if not t.closed then begin
+    t.closed <- true;
+    (match t.flow with
+    | Some flow ->
+        (try
+           send_frame t (Frame.close ());
+           Eio.Flow.close flow
+         with _ -> ());
+        t.flow <- None
+    | None -> ());
+    t.state <- Closed;
+    Logger.log_info ~section ~event:"CLOSED" []
+  end
+
+(** Start the connection with receive loop *)
+let start t =
+  Eio.Fiber.fork ~sw:t.sw (fun () ->
+      try
+        while not t.closed do
+          if t.state = Disconnected then connect_with_retry t;
+          if t.state = Connected then receive_loop t;
+          (* Small delay before reconnect attempt *)
+          if t.state = Disconnected && not t.closed then
+            Eio.Time.sleep t.clock 0.1
+        done
+      with Eio.Cancel.Cancelled _ ->
+        Logger.log_debug ~section ~event:"RECV_CANCELLED" [])
+
+(** Start ping loop *)
+let start_ping t = Eio.Fiber.fork ~sw:t.sw (fun () -> ping_loop t)

--- a/lib/websocket_client/dune
+++ b/lib/websocket_client/dune
@@ -1,0 +1,18 @@
+(library
+ (name polymarket_wss)
+ (public_name polymarket.wss)
+ (libraries
+  polymarket_common
+  polymarket_clob
+  eio
+  eio_main
+  yojson
+  ppx_yojson_conv_lib
+  tls-eio
+  ca-certs
+  cstruct
+  digestif
+  base64
+  logs)
+ (preprocess
+  (pps ppx_yojson_conv ppx_deriving.show ppx_deriving.eq)))

--- a/lib/websocket_client/frame.ml
+++ b/lib/websocket_client/frame.ml
@@ -1,0 +1,215 @@
+(** WebSocket frame encoding and decoding (RFC 6455).
+
+    This module implements the binary frame format for WebSocket messages.
+    Client frames must be masked; server frames are unmasked. *)
+
+(** Frame opcodes *)
+module Opcode = struct
+  type t = Continuation | Text | Binary | Close | Ping | Pong | Other of int
+
+  let to_int = function
+    | Continuation -> 0
+    | Text -> 1
+    | Binary -> 2
+    | Close -> 8
+    | Ping -> 9
+    | Pong -> 10
+    | Other n -> n
+
+  let of_int = function
+    | 0 -> Continuation
+    | 1 -> Text
+    | 2 -> Binary
+    | 8 -> Close
+    | 9 -> Ping
+    | 10 -> Pong
+    | n -> Other n
+
+  let is_control = function Close | Ping | Pong -> true | _ -> false
+end
+
+(** Close status codes *)
+module Close_code = struct
+  type t =
+    | Normal
+    | Going_away
+    | Protocol_error
+    | Unsupported_data
+    | No_status
+    | Abnormal
+    | Invalid_payload
+    | Policy_violation
+    | Message_too_big
+    | Missing_extension
+    | Internal_error
+    | Other of int
+
+  let to_int = function
+    | Normal -> 1000
+    | Going_away -> 1001
+    | Protocol_error -> 1002
+    | Unsupported_data -> 1003
+    | No_status -> 1005
+    | Abnormal -> 1006
+    | Invalid_payload -> 1007
+    | Policy_violation -> 1008
+    | Message_too_big -> 1009
+    | Missing_extension -> 1010
+    | Internal_error -> 1011
+    | Other n -> n
+
+  let of_int = function
+    | 1000 -> Normal
+    | 1001 -> Going_away
+    | 1002 -> Protocol_error
+    | 1003 -> Unsupported_data
+    | 1005 -> No_status
+    | 1006 -> Abnormal
+    | 1007 -> Invalid_payload
+    | 1008 -> Policy_violation
+    | 1009 -> Message_too_big
+    | 1010 -> Missing_extension
+    | 1011 -> Internal_error
+    | n -> Other n
+end
+
+type t = { fin : bool; opcode : Opcode.t; payload : string }
+(** A WebSocket frame *)
+
+(** Generate a random 4-byte masking key *)
+let generate_mask () =
+  let key = Bytes.create 4 in
+  for i = 0 to 3 do
+    Bytes.set key i (Char.chr (Random.int 256))
+  done;
+  Bytes.to_string key
+
+(** Apply XOR mask to payload *)
+let apply_mask ~key payload =
+  let len = String.length payload in
+  let result = Bytes.create len in
+  for i = 0 to len - 1 do
+    let masked = Char.code payload.[i] lxor Char.code key.[i mod 4] in
+    Bytes.set result i (Char.chr masked)
+  done;
+  Bytes.to_string result
+
+(** Encode a frame for sending (client must mask) *)
+let encode ~mask frame =
+  let payload_len = String.length frame.payload in
+  let buf = Buffer.create (14 + payload_len) in
+
+  (* First byte: FIN + opcode *)
+  let byte0 =
+    (if frame.fin then 0x80 else 0x00) lor Opcode.to_int frame.opcode
+  in
+  Buffer.add_char buf (Char.chr byte0);
+
+  (* Second byte: MASK + payload length *)
+  let mask_bit = if mask then 0x80 else 0x00 in
+  if payload_len < 126 then
+    Buffer.add_char buf (Char.chr (mask_bit lor payload_len))
+  else if payload_len < 65536 then begin
+    Buffer.add_char buf (Char.chr (mask_bit lor 126));
+    Buffer.add_char buf (Char.chr (payload_len lsr 8));
+    Buffer.add_char buf (Char.chr (payload_len land 0xFF))
+  end
+  else begin
+    Buffer.add_char buf (Char.chr (mask_bit lor 127));
+    (* 64-bit length - for simplicity, assume payload < 2^31 *)
+    for i = 7 downto 0 do
+      let shift = i * 8 in
+      if shift >= 32 then Buffer.add_char buf (Char.chr 0)
+      else Buffer.add_char buf (Char.chr ((payload_len lsr shift) land 0xFF))
+    done
+  end;
+
+  (* Masking key and masked payload (if mask) *)
+  if mask then begin
+    let key = generate_mask () in
+    Buffer.add_string buf key;
+    Buffer.add_string buf (apply_mask ~key frame.payload)
+  end
+  else Buffer.add_string buf frame.payload;
+
+  Buffer.contents buf
+
+(** Read exactly n bytes from a flow *)
+let read_exactly flow n =
+  let buf = Cstruct.create n in
+  let rec loop off remaining =
+    if remaining = 0 then ()
+    else begin
+      let got = Eio.Flow.single_read flow (Cstruct.sub buf off remaining) in
+      loop (off + got) (remaining - got)
+    end
+  in
+  loop 0 n;
+  Cstruct.to_string buf
+
+(** Decode a frame from a flow *)
+let decode flow =
+  (* Read first two bytes *)
+  let header = read_exactly flow 2 in
+  let byte0 = Char.code header.[0] in
+  let byte1 = Char.code header.[1] in
+
+  let fin = byte0 land 0x80 <> 0 in
+  let opcode = Opcode.of_int (byte0 land 0x0F) in
+  let masked = byte1 land 0x80 <> 0 in
+  let len0 = byte1 land 0x7F in
+
+  (* Extended payload length *)
+  let payload_len =
+    if len0 < 126 then len0
+    else if len0 = 126 then begin
+      let ext = read_exactly flow 2 in
+      (Char.code ext.[0] lsl 8) lor Char.code ext.[1]
+    end
+    else begin
+      let ext = read_exactly flow 8 in
+      (* Assume payload < 2^31 for simplicity *)
+      let len = ref 0 in
+      for i = 0 to 7 do
+        len := (!len lsl 8) lor Char.code ext.[i]
+      done;
+      !len
+    end
+  in
+
+  (* Masking key (if present) *)
+  let mask_key = if masked then Some (read_exactly flow 4) else None in
+
+  (* Payload *)
+  let payload = read_exactly flow payload_len in
+  let payload =
+    match mask_key with Some key -> apply_mask ~key payload | None -> payload
+  in
+
+  { fin; opcode; payload }
+
+(** Create a text frame *)
+let text ?(fin = true) payload = { fin; opcode = Text; payload }
+
+(** Create a binary frame *)
+let binary ?(fin = true) payload = { fin; opcode = Binary; payload }
+
+(** Create a ping frame *)
+let ping ?(payload = "") () = { fin = true; opcode = Ping; payload }
+
+(** Create a pong frame *)
+let pong ?(payload = "") () = { fin = true; opcode = Pong; payload }
+
+(** Create a close frame *)
+let close ?(code = Close_code.Normal) ?(reason = "") () =
+  let code_int = Close_code.to_int code in
+  let payload =
+    if code = Close_code.No_status then ""
+    else
+      let buf = Buffer.create (2 + String.length reason) in
+      Buffer.add_char buf (Char.chr (code_int lsr 8));
+      Buffer.add_char buf (Char.chr (code_int land 0xFF));
+      Buffer.add_string buf reason;
+      Buffer.contents buf
+  in
+  { fin = true; opcode = Close; payload }

--- a/lib/websocket_client/handshake.ml
+++ b/lib/websocket_client/handshake.ml
@@ -1,0 +1,144 @@
+(** WebSocket handshake implementation (RFC 6455 Section 4).
+
+    Performs HTTP/1.1 Upgrade handshake directly over a TLS flow. *)
+
+module Logger = Polymarket_common.Logger
+
+let section = "WSS_HANDSHAKE"
+
+(** WebSocket GUID for Sec-WebSocket-Accept calculation *)
+let websocket_guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+(** Generate a random 16-byte nonce and base64 encode it *)
+let generate_key () =
+  let bytes = Bytes.create 16 in
+  for i = 0 to 15 do
+    Bytes.set bytes i (Char.chr (Random.int 256))
+  done;
+  Base64.encode_string (Bytes.to_string bytes)
+
+(** Calculate expected Sec-WebSocket-Accept value *)
+let expected_accept key =
+  let concat = key ^ websocket_guid in
+  let hash = Digestif.SHA1.(digest_string concat |> to_raw_string) in
+  Base64.encode_string hash
+
+(** Read a line from flow (up to \r\n) *)
+let read_line flow =
+  let buf = Buffer.create 128 in
+  let rec loop prev_cr =
+    let byte_buf = Cstruct.create 1 in
+    let _ = Eio.Flow.single_read flow byte_buf in
+    let c = Cstruct.get_char byte_buf 0 in
+    if prev_cr && c = '\n' then
+      (* Remove trailing \r and return *)
+      let s = Buffer.contents buf in
+      if String.length s > 0 && s.[String.length s - 1] = '\r' then
+        String.sub s 0 (String.length s - 1)
+      else s
+    else begin
+      Buffer.add_char buf c;
+      loop (c = '\r')
+    end
+  in
+  loop false
+
+(** Parse HTTP response status line *)
+let parse_status_line line =
+  (* HTTP/1.1 101 Switching Protocols *)
+  match String.split_on_char ' ' line with
+  | version :: code :: _ ->
+      let code = int_of_string code in
+      (version, code)
+  | _ -> failwith ("Invalid HTTP status line: " ^ line)
+
+(** Parse HTTP headers until empty line *)
+let parse_headers flow =
+  let headers = Hashtbl.create 16 in
+  let rec loop () =
+    let line = read_line flow in
+    if String.length line = 0 then headers
+    else
+      match String.index_opt line ':' with
+      | Some i ->
+          let name =
+            String.lowercase_ascii (String.trim (String.sub line 0 i))
+          in
+          let value =
+            String.trim (String.sub line (i + 1) (String.length line - i - 1))
+          in
+          Hashtbl.add headers name value;
+          loop ()
+      | None ->
+          (* Malformed header, skip *)
+          loop ()
+  in
+  loop ()
+
+(** Handshake result *)
+type result = Success | Failed of string
+
+(** Perform WebSocket handshake over a TLS flow *)
+let perform ~flow ~host ~port ~resource =
+  Logger.log_info ~section ~event:"START"
+    [ ("host", host); ("port", string_of_int port); ("resource", resource) ];
+
+  (* Generate key for Sec-WebSocket-Key *)
+  let key = generate_key () in
+  let expected = expected_accept key in
+
+  (* Build HTTP request *)
+  let request =
+    Printf.sprintf
+      "GET %s HTTP/1.1\r\n\
+       Host: %s:%d\r\n\
+       Upgrade: websocket\r\n\
+       Connection: Upgrade\r\n\
+       Sec-WebSocket-Key: %s\r\n\
+       Sec-WebSocket-Version: 13\r\n\
+       Origin: https://polymarket.com\r\n\
+       User-Agent: polymarket-ocaml/1.0\r\n\
+       \r\n"
+      resource host port key
+  in
+
+  Logger.log_debug ~section ~event:"REQUEST" [ ("key", key) ];
+
+  (* Send request *)
+  Eio.Flow.copy_string request flow;
+
+  (* Read status line *)
+  let status_line = read_line flow in
+  Logger.log_debug ~section ~event:"STATUS" [ ("line", status_line) ];
+
+  let _version, status_code = parse_status_line status_line in
+
+  if status_code <> 101 then begin
+    let msg = Printf.sprintf "Expected 101, got %d" status_code in
+    Logger.log_err ~section ~event:"FAILED" [ ("error", msg) ];
+    Failed msg
+  end
+  else begin
+    (* Parse headers *)
+    let headers = parse_headers flow in
+
+    (* Verify Sec-WebSocket-Accept *)
+    let accept =
+      match Hashtbl.find_opt headers "sec-websocket-accept" with
+      | Some v -> v
+      | None -> ""
+    in
+
+    if accept <> expected then begin
+      let msg =
+        Printf.sprintf "Invalid Sec-WebSocket-Accept: expected %s, got %s"
+          expected accept
+      in
+      Logger.log_err ~section ~event:"FAILED" [ ("error", msg) ];
+      Failed msg
+    end
+    else begin
+      Logger.log_info ~section ~event:"SUCCESS" [];
+      Success
+    end
+  end

--- a/lib/websocket_client/types.ml
+++ b/lib/websocket_client/types.ml
@@ -1,0 +1,385 @@
+(** WebSocket message types for Polymarket WSS API.
+
+    This module defines types for the Market and User WebSocket channels. *)
+
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+(** {1 Channel Types} *)
+
+module Channel = struct
+  type t = Market | User [@@deriving show, eq]
+
+  let to_string = function Market -> "market" | User -> "user"
+
+  let of_string = function
+    | "market" | "MARKET" -> Market
+    | "user" | "USER" -> User
+    | s -> failwith ("Unknown channel: " ^ s)
+end
+
+(** {1 Common Types} *)
+
+type order_summary = { price : string; size : string }
+[@@deriving yojson, show, eq]
+
+(** {1 Market Channel Message Types} *)
+
+module Market_event = struct
+  type t =
+    | Book
+    | Price_change
+    | Tick_size_change
+    | Last_trade_price
+    | Best_bid_ask
+  [@@deriving show, eq]
+
+  let to_string = function
+    | Book -> "book"
+    | Price_change -> "price_change"
+    | Tick_size_change -> "tick_size_change"
+    | Last_trade_price -> "last_trade_price"
+    | Best_bid_ask -> "best_bid_ask"
+
+  let of_string = function
+    | "book" -> Book
+    | "price_change" -> Price_change
+    | "tick_size_change" -> Tick_size_change
+    | "last_trade_price" -> Last_trade_price
+    | "best_bid_ask" -> Best_bid_ask
+    | s -> failwith ("Unknown market event type: " ^ s)
+
+  let t_of_yojson = function
+    | `String s -> of_string s
+    | _ -> failwith "Market_event.t_of_yojson: expected string"
+
+  let yojson_of_t t = `String (to_string t)
+end
+
+type book_message = {
+  event_type : string; [@key "event_type"]
+  asset_id : string; [@key "asset_id"]
+  market : string;
+  timestamp : string;
+  hash : string;
+  bids : order_summary list;
+  asks : order_summary list;
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Book message - full orderbook snapshot *)
+
+type price_change_entry = {
+  asset_id : string; [@key "asset_id"]
+  price : string;
+  size : string;
+  side : string;
+  hash : string;
+  best_bid : string; [@key "best_bid"]
+  best_ask : string; [@key "best_ask"]
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Price change entry within a price_change message *)
+
+type price_change_message = {
+  event_type : string; [@key "event_type"]
+  market : string;
+  price_changes : price_change_entry list; [@key "price_changes"]
+  timestamp : string;
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Price change message - incremental orderbook update *)
+
+type tick_size_change_message = {
+  event_type : string; [@key "event_type"]
+  asset_id : string; [@key "asset_id"]
+  market : string;
+  old_tick_size : string; [@key "old_tick_size"]
+  new_tick_size : string; [@key "new_tick_size"]
+  side : string option; [@default None]
+  timestamp : string;
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Tick size change message *)
+
+type last_trade_price_message = {
+  event_type : string; [@key "event_type"]
+  asset_id : string; [@key "asset_id"]
+  market : string;
+  price : string;
+  side : string;
+  size : string;
+  fee_rate_bps : string; [@key "fee_rate_bps"]
+  timestamp : string;
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Last trade price message *)
+
+type best_bid_ask_message = {
+  event_type : string; [@key "event_type"]
+  asset_id : string; [@key "asset_id"]
+  market : string;
+  best_bid : string; [@key "best_bid"]
+  best_ask : string; [@key "best_ask"]
+  timestamp : string;
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Best bid/ask message *)
+
+(** {1 User Channel Message Types} *)
+
+module User_event = struct
+  type t = Trade | Order [@@deriving show, eq]
+
+  let to_string = function Trade -> "trade" | Order -> "order"
+
+  let of_string = function
+    | "trade" -> Trade
+    | "order" -> Order
+    | s -> failwith ("Unknown user event type: " ^ s)
+
+  let t_of_yojson = function
+    | `String s -> of_string s
+    | _ -> failwith "User_event.t_of_yojson: expected string"
+
+  let yojson_of_t t = `String (to_string t)
+end
+
+module Trade_status = struct
+  type t = Matched | Mined | Confirmed | Retrying | Failed
+  [@@deriving show, eq]
+
+  let to_string = function
+    | Matched -> "MATCHED"
+    | Mined -> "MINED"
+    | Confirmed -> "CONFIRMED"
+    | Retrying -> "RETRYING"
+    | Failed -> "FAILED"
+
+  let of_string = function
+    | "MATCHED" -> Matched
+    | "MINED" -> Mined
+    | "CONFIRMED" -> Confirmed
+    | "RETRYING" -> Retrying
+    | "FAILED" -> Failed
+    | s -> failwith ("Unknown trade status: " ^ s)
+
+  let t_of_yojson = function
+    | `String s -> of_string s
+    | _ -> failwith "Trade_status.t_of_yojson: expected string"
+
+  let yojson_of_t t = `String (to_string t)
+end
+
+module Order_event_type = struct
+  type t = Placement | Update | Cancellation [@@deriving show, eq]
+
+  let to_string = function
+    | Placement -> "PLACEMENT"
+    | Update -> "UPDATE"
+    | Cancellation -> "CANCELLATION"
+
+  let of_string = function
+    | "PLACEMENT" -> Placement
+    | "UPDATE" -> Update
+    | "CANCELLATION" -> Cancellation
+    | s -> failwith ("Unknown order event type: " ^ s)
+
+  let t_of_yojson = function
+    | `String s -> of_string s
+    | _ -> failwith "Order_event_type.t_of_yojson: expected string"
+
+  let yojson_of_t t = `String (to_string t)
+end
+
+type maker_order = {
+  asset_id : string; [@key "asset_id"]
+  matched_amount : string; [@key "matched_amount"]
+  order_id : string; [@key "order_id"]
+  outcome : string;
+  owner : string;
+  price : string;
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Maker order in a trade *)
+
+type trade_message = {
+  event_type : string; [@key "event_type"]
+  id : string;
+  asset_id : string; [@key "asset_id"]
+  market : string;
+  side : string;
+  size : string;
+  price : string;
+  status : Trade_status.t;
+  outcome : string;
+  owner : string;
+  trade_owner : string; [@key "trade_owner"]
+  taker_order_id : string; [@key "taker_order_id"]
+  maker_orders : maker_order list; [@key "maker_orders"]
+  matchtime : string;
+  last_update : string; [@key "last_update"]
+  timestamp : string;
+  type_ : string; [@key "type"]
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Trade message from user channel *)
+
+type order_message = {
+  event_type : string; [@key "event_type"]
+  id : string;
+  asset_id : string; [@key "asset_id"]
+  market : string;
+  side : string;
+  price : string;
+  original_size : string; [@key "original_size"]
+  size_matched : string; [@key "size_matched"]
+  outcome : string;
+  owner : string;
+  order_owner : string; [@key "order_owner"]
+  associate_trades : string list option;
+      [@key "associate_trades"] [@default None]
+  timestamp : string;
+  type_ : Order_event_type.t; [@key "type"]
+}
+[@@yojson.allow_extra_fields] [@@deriving yojson, show, eq]
+(** Order message from user channel *)
+
+(** {1 Unified Message Type} *)
+
+type market_message =
+  | Book of book_message
+  | Price_change of price_change_message
+  | Tick_size_change of tick_size_change_message
+  | Last_trade_price of last_trade_price_message
+  | Best_bid_ask of best_bid_ask_message
+[@@deriving show, eq]
+
+type user_message = Trade of trade_message | Order of order_message
+[@@deriving show, eq]
+
+type message =
+  | Market of market_message
+  | User of user_message
+  | Unknown of string
+[@@deriving show, eq]
+
+(** {1 Message Parsing} *)
+
+let parse_market_message (json : Yojson.Safe.t) : market_message =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "event_type" fields with
+      | Some (`String "book") -> Book (book_message_of_yojson json)
+      | Some (`String "price_change") ->
+          Price_change (price_change_message_of_yojson json)
+      | Some (`String "tick_size_change") ->
+          Tick_size_change (tick_size_change_message_of_yojson json)
+      | Some (`String "last_trade_price") ->
+          Last_trade_price (last_trade_price_message_of_yojson json)
+      | Some (`String "best_bid_ask") ->
+          Best_bid_ask (best_bid_ask_message_of_yojson json)
+      | Some (`String s) -> failwith ("Unknown market event_type: " ^ s)
+      | _ -> failwith "Missing or invalid event_type in market message")
+  | _ -> failwith "Market message must be a JSON object"
+
+let parse_user_message (json : Yojson.Safe.t) : user_message =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "event_type" fields with
+      | Some (`String "trade") -> Trade (trade_message_of_yojson json)
+      | Some (`String "order") -> Order (order_message_of_yojson json)
+      | Some (`String s) -> failwith ("Unknown user event_type: " ^ s)
+      | _ -> failwith "Missing or invalid event_type in user message")
+  | _ -> failwith "User message must be a JSON object"
+
+let parse_message ~channel (raw : string) : message list =
+  try
+    let json = Yojson.Safe.from_string raw in
+    match json with
+    | `List [] -> [] (* Empty array is subscription ack, skip it *)
+    | `List items ->
+        (* Array of messages - parse each one *)
+        List.filter_map
+          (fun item ->
+            try
+              Some
+                (match channel with
+                | Channel.Market -> Market (parse_market_message item)
+                | Channel.User -> User (parse_user_message item))
+            with _ -> None)
+          items
+    | _ ->
+        (* Single message object *)
+        [
+          (match channel with
+          | Channel.Market -> Market (parse_market_message json)
+          | Channel.User -> User (parse_user_message json));
+        ]
+  with e ->
+    [
+      Unknown (Printf.sprintf "Parse error: %s - %s" (Printexc.to_string e) raw);
+    ]
+
+(** {1 Subscription Request Types} *)
+
+type auth = {
+  apiKey : string; [@key "apiKey"]
+  secret : string;
+  passphrase : string;
+}
+[@@deriving yojson, show]
+
+type market_subscribe_request = {
+  assets_ids : string list; [@key "assets_ids"]
+  type_ : string; [@key "type"]
+  custom_feature_enabled : bool; [@key "custom_feature_enabled"]
+}
+[@@deriving yojson]
+
+type user_subscribe_request = {
+  markets : string list;
+  auth : auth;
+  type_ : string; [@key "type"]
+}
+[@@deriving yojson]
+
+type asset_subscription_request = {
+  assets_ids : string list; [@key "assets_ids"]
+  operation : string;
+  custom_feature_enabled : bool; [@key "custom_feature_enabled"]
+}
+[@@deriving yojson]
+
+let market_subscribe_json ~asset_ids =
+  yojson_of_market_subscribe_request
+    { assets_ids = asset_ids; type_ = "MARKET"; custom_feature_enabled = true }
+  |> Yojson.Safe.to_string
+
+let user_subscribe_json ~(credentials : Polymarket_clob.Auth_types.credentials)
+    ~markets =
+  let auth =
+    {
+      apiKey = credentials.api_key;
+      secret = credentials.secret;
+      passphrase = credentials.passphrase;
+    }
+  in
+  yojson_of_user_subscribe_request { markets; auth; type_ = "USER" }
+  |> Yojson.Safe.to_string
+
+let subscribe_assets_json ~asset_ids =
+  yojson_of_asset_subscription_request
+    {
+      assets_ids = asset_ids;
+      operation = "subscribe";
+      custom_feature_enabled = true;
+    }
+  |> Yojson.Safe.to_string
+
+let unsubscribe_assets_json ~asset_ids =
+  yojson_of_asset_subscription_request
+    {
+      assets_ids = asset_ids;
+      operation = "unsubscribe";
+      custom_feature_enabled = true;
+    }
+  |> Yojson.Safe.to_string


### PR DESCRIPTION
Implement WebSocket streaming for Polymarket using tls-eio instead of OpenSSL, enabling cross-platform compatibility (including Windows).

New module: polymarket.wss
- Market channel: public orderbook updates, price changes, trades
- User channel: authenticated trade and order notifications
- Auto-reconnection with exponential backoff
- RFC 6455 compliant frame encoding/decoding
- HTTP/1.1 upgrade handshake over TLS

Files added:
- lib/websocket_client/{frame,handshake,connection,client,types}.ml
- examples/wss_demo.ml