### PR TITLE
build: restrict to x86_64 and arm64 architectures

### DIFF
--- a/polymarket.opam
+++ b/polymarket.opam
@@ -55,3 +55,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/haut/polymarket.git"
+available: arch = "x86_64" | arch = "arm64" | arch = "aarch64"

--- a/polymarket.opam.template
+++ b/polymarket.opam.template
@@ -1,0 +1,1 @@
+available: arch = "x86_64" | arch = "arm64" | arch = "aarch64"


### PR DESCRIPTION
## Summary
- Add `available` constraint to opam file to skip unsupported architectures (riscv64, s390x, ppc64le, etc.)
- Uses `polymarket.opam.template` since dune doesn't support the `available` field directly

## Context
The opam-repository CI was failing on exotic architectures like riscv64 due to missing dependencies (secp256k1-internal). This constraint ensures the package only builds on supported platforms.

## Test plan
- [x] Build succeeds locally
- [ ] opam-repository CI passes on x86_64/arm64