### PR TITLE
fix: use normalized arm64 arch string for opam

### DIFF
--- a/polymarket.opam
+++ b/polymarket.opam
@@ -55,4 +55,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/haut/polymarket.git"
-available: arch = "x86_64" | arch = "arm64" | arch = "aarch64"
+available: arch = "x86_64" | arch = "arm64"

--- a/polymarket.opam.template
+++ b/polymarket.opam.template
@@ -1,1 +1,1 @@
-available: arch = "x86_64" | arch = "arm64" | arch = "aarch64"
+available: arch = "x86_64" | arch = "arm64"


### PR DESCRIPTION
## Summary
- Replace `aarch64` with `arm64` per opam-repository validation requirements
- Fixes error 55: "Non-normalised OS or arch string being tested"

## Context
opam-repository linting requires the normalized arch string `arm64` instead of `aarch64`.